### PR TITLE
Fix clear-notebook-outputs in make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,4 +44,4 @@ update-notebooks:
 	rm experiments/notebooks/*.nbconvert.* || true
 
 clear-notebook-outputs:
-	jupyter nbconvert --clear-output --inplace experiments/notebooks/*.ipynb
+	jupyter nbconvert --ClearOutputPreprocessor.enabled=True --inplace experiments/notebooks/*.ipynb


### PR DESCRIPTION
To compensate for a long standing bug in nbconvert, apparently fixed in 6.0
[--clear-output flag is broken · Issue #822 · jupyter/nbconvert](https://github.com/jupyter/nbconvert/issues/822)