### PR TITLE
Fix slashing parameter

### DIFF
--- a/docs/model_specification/mathematical_specification.md
+++ b/docs/model_specification/mathematical_specification.md
@@ -194,7 +194,7 @@ All System Parameters in this category use the same uppercase snake-case variabl
 | `EFFECTIVE_BALANCE_INCREMENT` | `1e9` | $\text{Gwei}$ |
 | `PROPOSER_REWARD_QUOTIENT` | `8` | None |
 | `WHISTLEBLOWER_REWARD_QUOTIENT` | `512` | None |
-| `MIN_SLASHING_PENALTY_QUOTIENT` | `32` | None |
+| `MIN_SLASHING_PENALTY_QUOTIENT` | `64` | None |
 | `PROPORTIONAL_SLASHING_MULTIPLIER` | `2` | None |
 | `TIMELY_HEAD_WEIGHT` | `14` | None |
 | `TIMELY_SOURCE_WEIGHT` | `14` | None |
@@ -769,7 +769,7 @@ All System Parameters in this category use the same uppercase snake-case variabl
 | `EFFECTIVE_BALANCE_INCREMENT` | `1e9` | $\text{Gwei}$ |
 | `PROPOSER_REWARD_QUOTIENT` | `8` | None |
 | `WHISTLEBLOWER_REWARD_QUOTIENT` | `512` | None |
-| `MIN_SLASHING_PENALTY_QUOTIENT` | `32` | None |
+| `MIN_SLASHING_PENALTY_QUOTIENT` | `64` | None |
 | `PROPORTIONAL_SLASHING_MULTIPLIER` | `2` | None |
 | `TIMELY_HEAD_WEIGHT` | `14` | None |
 | `TIMELY_SOURCE_WEIGHT` | `14` | None |


### PR DESCRIPTION
[Altair upgrade](https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/beacon-chain.md#updated-penalty-values) states `MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR` is `2**6 (= 64)`. 
In Ethereum Economic Model, the value of `MIN_SLASHING_PENALTY_QUOTIENT` in [Mathematical_specification.md](https://github.com/CADLabs/ethereum-economic-model/blob/main/docs/model_specification/mathematical_specification.md) is `32` and `64` in the other files.